### PR TITLE
Expose net_version() function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ const AlphaWallet = {
     engine.enable = options.enable
     engine.chainId = syncOptions.networkVersion
     engine.isAlphaWallet = true
+	engine.net_version = function(){ return globalSyncOptions.networkVersion || null; } // hack to expose window.ethereum.net_version() as expected by dapps
     engine.start()
 
     return engine


### PR DESCRIPTION
Exposes ```window.ethereum.net_version()``` function which some newer dapps use to determine which network they are running on (eg Quickswap). Provides a better experience as if you are on the wrong network the dapp will ask you to change networks, instead of not displaying any wallet.

In newer builds of provider, there is an additional switch table that funnels all these functions into the correct call in the provider, eg ```eth_accounts```.